### PR TITLE
normaliseImageName() fails for image names with 3+ slashes

### DIFF
--- a/lib/docker-toolbelt.coffee
+++ b/lib/docker-toolbelt.coffee
@@ -337,13 +337,17 @@ DockerToolbelt::createDeltaAsync = (src, dest, onProgress) ->
 #          { registry: "registry.resinstaging.io", imageName: "resin/rpi" }
 DockerToolbelt::getRegistryAndName = Promise.method (image) ->
 	# Matches (registry)/(repo)(optional :tag or @digest)
-	# The regex for digest is adapted from https://github.com/docker/distribution/blob/95daa793b83a21656fe6c13e6d5cf1c3999108c7/reference/regexp.go#L44
-	match = image.match(/^(?:([^\/:.]+\.[^\/:]+(?::[0-9]+)?)\/)?([^\/:@]+(?:\/[^\/:@]+)?)(?:(?::(.*))|(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9a-f-A-F]{32,})))?$/)
+	# regex adapted from Docker's source code:
+	# https://github.com/docker/distribution/blob/release/2.7/reference/normalize.go#L62
+	# https://github.com/docker/distribution/blob/release/2.7/reference/regexp.go#L44
+	match = image.match /^(?:(localhost|.*?[.:].*?)\/)?(.+?)(?::(.*?))?(?:@(.*?))?$/
 	throw new Error("Could not parse the image: #{image}") if not match?
 	[ ..., registry, imageName, tagName, digest ] = match
 	if !digest? and !tagName?
 		tagName = 'latest'
-	throw new Error('Invalid image name, expected domain.tld/repo/image format.') if not imageName
+	digestMatch = digest?.match /^[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9a-f-A-F]{32,}$/
+	if not imageName or digest and not digestMatch
+		throw new Error('Invalid image name, expected [domain.tld/]repo/image[:tag][@digest] format')
 	return { registry, imageName, tagName, digest }
 
 # Given an object representing a docker image, in the same format as given
@@ -359,6 +363,7 @@ DockerToolbelt::compileRegistryAndName = Promise.method ({ registry = '', imageN
 			tagName = 'latest'
 		return "#{registry}#{imageName}:#{tagName}"
 	else
+		# Intentionally discard the tag when a digest exists
 		return "#{registry}#{imageName}@#{digest}"
 
 # Normalise an image name to always have a tag, with :latest being the default

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-toolbelt",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/docker-toolbelt.spec.coffee
+++ b/test/docker-toolbelt.spec.coffee
@@ -77,3 +77,67 @@ describe 'DockerToolbelt', ->
 
 	it 'throws when running getRegistryAndName if the image name has an invalid digest', ->
 		expect(@d.getRegistryAndName('someregistry.com/some/repo@sha256:0123456789abcdef0123456789abcdeg')).to.be.rejected
+
+	it 'successfully parses a list of sample docker image names', ->
+		u = undefined
+		testVector = [
+			['busybox', [u, 'busybox', 'latest', u]]
+			['localhost/busybox', ['localhost', 'busybox', 'latest', u]]
+			['busybox:3', [u, 'busybox', '3', u]]
+			['localhost/busybox:3', ['localhost', 'busybox', '3', u]]
+			['arm/busybox:3', [u, 'arm/busybox', '3', u]]
+			['arm.com/busybox:3', ['arm.com', 'busybox', '3', u]]
+			['arm.com/arm/busybox:3', ['arm.com', 'arm/busybox', '3', u]]
+			['arm.com:5000/arm/busybox:3', ['arm.com:5000', 'arm/busybox', '3', u]]
+			['a/b/c/d:1', [u, 'a/b/c/d', '1', u]]
+			['a.b/c/d:1', ['a.b', 'c/d', '1', u]]
+			['a.b:1', [u, 'a.b', '1', u]]
+			['a/b/c/d:1@a:0123456789abcdef0123456789abcdef', [u, 'a/b/c/d', '1', 'a:0123456789abcdef0123456789abcdef']]
+			['a.b/c/d:1@a:0123456789abcdef0123456789abcdef', ['a.b', 'c/d', '1', 'a:0123456789abcdef0123456789abcdef']]
+			['a.b@a:0123456789abcdef0123456789abcdef', [u, 'a.b', u, 'a:0123456789abcdef0123456789abcdef']]
+			['[::1]:5000/busybox', ['[::1]:5000', 'busybox', 'latest', u]]
+			['[::1]:5000/busybox:3', ['[::1]:5000', 'busybox', '3', u]]
+			['127.0.0.1/busybox', ['127.0.0.1', 'busybox', 'latest', u]]
+			['127.0.0.1/arm/busybox', ['127.0.0.1', 'arm/busybox', 'latest', u]]
+			['127.0.0.1:5000/busybox', ['127.0.0.1:5000', 'busybox', 'latest', u]]
+			['127.0.0.1/busybox:3', ['127.0.0.1', 'busybox', '3', u]]
+			['127.0.0.1:5000/busybox:3', ['127.0.0.1:5000', 'busybox', '3', u]]
+			['127.0.0.1:5000/arm/busybox:3', ['127.0.0.1:5000', 'arm/busybox', '3', u]]
+			['eu.gcr.io/aa-bb-33/foo/bar', ['eu.gcr.io', 'aa-bb-33/foo/bar', 'latest', u]]
+		]
+		Promise.map testVector, ([fullName, [registry, imageName, tagName, digest]]) ->
+			DockerToolbelt::getRegistryAndName fullName
+			.then (components) ->
+				expect(components).to.deep.equal({ registry, imageName, tagName, digest })
+
+	it 'successfully compiles a list of sample docker image names', ->
+		u = undefined
+		testVector = [
+			['busybox:latest', [u, 'busybox', u, u]]
+			['localhost/busybox:latest', ['localhost', 'busybox', u, u]]
+			['busybox:3', [u, 'busybox', '3', u]]
+			['localhost/busybox:3', ['localhost', 'busybox', '3', u]]
+			['arm/busybox:3', [u, 'arm/busybox', '3', u]]
+			['arm.com/busybox:3', ['arm.com', 'busybox', '3', u]]
+			['arm.com/arm/busybox:3', ['arm.com', 'arm/busybox', '3', u]]
+			['arm.com:5000/arm/busybox:3', ['arm.com:5000', 'arm/busybox', '3', u]]
+			['a/b/c/d/e:1', [u, 'a/b/c/d/e', '1', u]]
+			['a.b/c/d/e:1', ['a.b', 'c/d/e', '1', u]]
+			['a.b:1', [u, 'a.b', '1', u]]
+			['a/b/c/d@a:0123456789abcdef0123456789abcdef', [u, 'a/b/c/d', '1', 'a:0123456789abcdef0123456789abcdef']]
+			['a.b/c/d@a:0123456789abcdef0123456789abcdef', ['a.b', 'c/d', '1', 'a:0123456789abcdef0123456789abcdef']]
+			['a.b@a:0123456789abcdef0123456789abcdef', [u, 'a.b', u, 'a:0123456789abcdef0123456789abcdef']]
+			['[::1]:5000/busybox:latest', ['[::1]:5000', 'busybox', u, u]]
+			['[::1]:5000/busybox:3', ['[::1]:5000', 'busybox', '3', u]]
+			['127.0.0.1/busybox:latest', ['127.0.0.1', 'busybox', '', u]]
+			['127.0.0.1/arm/busybox:latest', ['127.0.0.1', 'arm/busybox', '', u]]
+			['127.0.0.1:5000/busybox:latest', ['127.0.0.1:5000', 'busybox', '', u]]
+			['127.0.0.1/busybox:3', ['127.0.0.1', 'busybox', '3', u]]
+			['127.0.0.1:5000/busybox:3', ['127.0.0.1:5000', 'busybox', '3', u]]
+			['127.0.0.1:5000/arm/busybox:3', ['127.0.0.1:5000', 'arm/busybox', '3', u]]
+			['eu.gcr.io/aa-bb-33/foo/bar:latest', ['eu.gcr.io', 'aa-bb-33/foo/bar', '', u]]
+		]
+		Promise.map testVector, ([expectedFullName, [registry, imageName, tagName, digest]]) ->
+			DockerToolbelt::compileRegistryAndName { registry, imageName, tagName, digest }
+			.then (fullName) ->
+				expect(fullName).to.equal(expectedFullName)


### PR DESCRIPTION
Resolves: #32 
Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>