### PR TITLE
Fix typings for class methods

### DIFF
--- a/lib/docker-toolbelt.d.ts
+++ b/lib/docker-toolbelt.d.ts
@@ -10,15 +10,19 @@ declare interface ImageNameParts {
 
 declare class DockerToolbelt extends Docker {
 	constructor(opts: any);
-	static imageRootDir(image: string): Bluebird<string>;
-	static imageRootDirMounted(image: string): Bluebird.Disposer<string>;
-	static diffPaths(image: string): Bluebird<string>;
-	static aufsDiffPaths(image: string): Bluebird<string>;
-	static createEmptyImage(imageConfig: any): Bluebird<string>;
-	static createDeltaAsync(src: string, dest: string, onProgress?: (args: any) => void): Bluebird<void>;
-	static getRegistryAndName(image: any): Bluebird<ImageNameParts>;
-	static compileRegistryAndName(image: ImageNameParts): Bluebird<string>;
-	static normaliseImageName(name: string): Bluebird<string>;
+	imageRootDir(image: string): Bluebird<string>;
+	imageRootDirMounted(image: string): Bluebird.Disposer<string>;
+	diffPaths(image: string): Bluebird<string>;
+	aufsDiffPaths(image: string): Bluebird<string>;
+	createEmptyImage(imageConfig: any): Bluebird<string>;
+	createDeltaAsync(
+		src: string,
+		dest: string,
+		onProgress?: (args: any) => void,
+	): Bluebird<void>;
+	getRegistryAndName(image: any): Bluebird<ImageNameParts>;
+	compileRegistryAndName(image: ImageNameParts): Bluebird<string>;
+	normaliseImageName(name: string): Bluebird<string>;
 }
 
 export = DockerToolbelt;


### PR DESCRIPTION
When I wrote the typings I incorrectly parsed the coffeescript as generating static functions, but this is in fact not the case, at least from a typescript perspective.

I'm not sure if this should be a major change or not, as anybody using this + typescript, wouldn't have been able to use it anyway.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>