### PR TITLE
Ensure daemon events aren’t buffered during a delta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-toolbelt",
-  "version": "3.3.5",
+  "version": "3.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -76,9 +76,9 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -799,6 +799,15 @@
         "split-ca": "^1.0.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+          "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+          "requires": {
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
+          }
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@types/bluebird": "^3.5.23",
     "@types/dockerode": "^2.5.5",
+    "JSONStream": "^1.3.5",
     "bluebird": "^3.4.1",
     "dockerode": "^2.5.0",
     "event-stream": "3.3.5",


### PR DESCRIPTION
DockerModem.followProgress buffers all events internally and hands them all to the onFinish callback, which can be problematic. This adds a copy of that function without the buffering.

Change-type: patch