### PR TITLE
Add typedoc generation and autopublish to docs branch

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,34 @@
+# This workflow will install the dependencies and then build and deploy the
+# TypeScript documentation website to the docs branch.
+
+name: Publish Documentation
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+
+      - name: Install NPM dependencies
+        run: npm i
+
+      - name: Generate docs
+        run: npm run doc
+
+      - name: Publish generated docs to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs
+          publish_branch: docs

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ jspm_packages
 
 build
 .DS_Store
+
+# Doc files should not be committed. They are generated using
+# the command 'npm run doc' and committed to the root of the
+# 'docs' branch.
+docs/

--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ const belt = new DockerToolbelt({
 
 const containers = await belt.listContainers()
 ```
+
+## Documentation
+
+[![Publish Documentation](https://github.com/balena-io-modules/docker-toolbelt/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/balena-io-modules/docker-toolbelt/actions/workflows/publish-docs.yml)
+
+Visit the website for complete documentation: https://balena-io-modules.github.io/docker-toolbelt

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint-fix": "balena-lint --typescript --fix lib tests",
     "test": "npm run build && npm run lint && npm run test:fast",
     "test:fast": "mocha -r ts-node/register --reporter spec tests/**/*.spec.ts",
+    "doc": "typedoc lib/ && touch docs/.nojekyll",
     "prepack": "npm run build"
   },
   "repository": {
@@ -47,6 +48,7 @@
     "rimraf": "^3.0.2",
     "sinon": "^12.0.1",
     "ts-node": "^10.4.0",
+    "typedoc": "^0.22.9",
     "typescript": "^4.4.4"
   },
   "versionist": {


### PR DESCRIPTION
This commit uses typedoc to generate documentation from source code.
It also adds a small GitHub action that will build and publish the docs
to the `docs` branch after a version bump, so that they can be served from
GitHub pages.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>