### PR TITLE
Overhaul API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A belt full of tools for working with Docker.
 
-Docker Toolbelt extends [dockerode](https://github.com/apocas/dockerode) with additional utilities to make working with Docker a breeze. This module also supports [balenaEngine](https://github.com/balena-os/balena-engine), notably its [delta generation feature](https://www.balena.io/engine/docs/#Container-deltas).
+Docker Toolbelt provide utilities to work with Docker's layer store and it leverages [dockerode](https://github.com/apocas/dockerode) to implement a few conveniences. This module also supports [balenaEngine](https://github.com/balena-os/balena-engine), notably its [delta generation feature](https://www.balena.io/engine/docs/#Container-deltas).
 
 ## Installation
 
@@ -12,22 +12,10 @@ Install `docker-toolbelt` by running:
 $ npm install --save docker-toolbelt
 ```
 
-## Usage
-
-```js
-import { DockerToolbelt } from 'docker-toolbelt'
-
-const belt = new DockerToolbelt({
-  host: '192.168.1.10',
-  port: process.env.DOCKER_PORT || 2375,
-	...
-});
-
-const containers = await belt.listContainers()
-```
+`dockerode` is a peer dependency that must be satisfied explicitly.
 
 ## Documentation
 
 [![Publish Documentation](https://github.com/balena-io-modules/docker-toolbelt/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/balena-io-modules/docker-toolbelt/actions/workflows/publish-docs.yml)
 
-Visit the website for complete documentation: https://balena-io-modules.github.io/docker-toolbelt
+Visit the website for complete API reference: https://balena-io-modules.github.io/docker-toolbelt

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -533,12 +533,12 @@ export class DockerToolbelt extends Docker {
 	// can be used in Docker command etc
 	// Example: { registry: "registry.resinstaging.io", imageName: "resin/rpi", tagName: "1234"}
 	// 		=> registry.resinstaging.io/resin/rpi:1234
-	async compileRegistryAndName({
+	compileRegistryAndName({
 		registry = '',
 		imageName,
 		tagName = '',
 		digest,
-	}: ImageNameParts): Promise<string> {
+	}: ImageNameParts): string {
 		if (registry !== '') {
 			registry += '/';
 		}
@@ -555,8 +555,8 @@ export class DockerToolbelt extends Docker {
 	}
 
 	// Normalise an image name to always have a tag, with :latest being the default
-	async normaliseImageName(image: string): Promise<string> {
-		const result = await this.getRegistryAndName(image);
+	normaliseImageName(image: string): string {
+		const result = this.getRegistryAndName(image);
 		return this.compileRegistryAndName(result);
 	}
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -590,4 +590,15 @@ export class DockerToolbelt extends Docker {
 		const result = this.getRegistryAndName(image);
 		return this.compileRegistryAndName(result);
 	}
+
+	async isBalenaEngine(): Promise<boolean> {
+		const versionInfo = await this.version();
+		const engine = (versionInfo as any)['Engine'];
+		if (engine == null) {
+			return false;
+		}
+		return ['balena', 'balaena', 'balena-engine'].includes(
+			engine.toLowerCase(),
+		);
+	}
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,14 +1,16 @@
+import type Docker from 'dockerode';
+
 import * as crypto from 'crypto';
-import { promisify } from 'util';
-import Docker from 'dockerode';
-import * as semver from 'balena-semver';
-import * as tar from 'tar-stream';
 import * as es from 'event-stream';
 import * as JSONStream from 'JSONStream';
-import { promises as fs } from 'fs';
 import * as path from 'path';
 import * as randomstring from 'randomstring';
+import * as semver from 'balena-semver';
+import * as tar from 'tar-stream';
 import { exec } from 'child_process';
+import { promises as fs } from 'fs';
+import { promisify } from 'util';
+
 const execAsync = promisify(exec);
 
 const MIN_PAGE_SIZE = 4096;
@@ -27,9 +29,9 @@ export interface ImageNameParts {
 	digest: string;
 }
 
-const promiseFromCallback = <T>(
+async function promiseFromCallback<T>(
 	fn: (callback: (err: any, data: T) => any) => any,
-): Promise<T> => {
+): Promise<T> {
 	return new Promise((resolve, reject) => {
 		fn((err, data) => {
 			if (err) {
@@ -38,22 +40,31 @@ const promiseFromCallback = <T>(
 			resolve(data);
 		});
 	});
-};
+}
 
-const sha256sum = (data: string): string => {
+async function waitStream<T>(stream: NodeJS.ReadableStream) {
+	return await promiseFromCallback<T>((callback) =>
+		stream.pipe(es.wait(callback)),
+	);
+}
+
+function sha256sum(data: string): string {
 	const hash = crypto.createHash('sha256');
 	hash.update(data);
 	return hash.digest('hex');
-};
+}
 
-const getDigest = (data: string): string => 'sha256:' + sha256sum(data);
+function getDigest(data: string): string {
+	return 'sha256:' + sha256sum(data);
+}
 
 // Function adapted to JavaScript from
 // https://github.com/docker/docker/blob/v1.10.3/layer/layer.go#L223-L226
-const createChainId = (diffIds: string[]): string =>
-	createChainIdFromParent('', diffIds);
+function createChainId(diffIds: string[]): string {
+	return createChainIdFromParent('', diffIds);
+}
 
-const getAllChainIds = function (diffIds: string[]): string[] {
+function getAllChainIds(diffIds: string[]): string[] {
 	const chainIds = [diffIds[0]];
 	for (
 		let i = 0, end = diffIds.length - 1, asc = 0 <= end;
@@ -63,11 +74,11 @@ const getAllChainIds = function (diffIds: string[]): string[] {
 		chainIds.push(createChainIdFromParent(chainIds[i], [diffIds[i + 1]]));
 	}
 	return chainIds;
-};
+}
 
 // Function adapted to JavaScript from
 // https://github.com/docker/docker/blob/v1.10.3/layer/layer.go#L223-L226
-const createChainIdFromParent = (parent: string, dgsts: string[]): string => {
+function createChainIdFromParent(parent: string, dgsts: string[]): string {
 	if (dgsts.length === 0) {
 		return parent;
 	}
@@ -80,21 +91,21 @@ const createChainIdFromParent = (parent: string, dgsts: string[]): string => {
 	const dgst = getDigest(parent + ' ' + dgsts[0]);
 
 	return createChainIdFromParent(dgst, dgsts.slice(1));
-};
+}
 
-const getDiffIds = async (
+async function getDiffIds(
 	dkroot: string,
 	driver: string,
 	imageId: string,
-): Promise<string[]> => {
+): Promise<string[]> {
 	const [hashType, hash] = Array.from(imageId.split(':'));
 	const content = await fs.readFile(
 		path.join(dkroot, `image/${driver}/imagedb/content`, hashType, hash),
 	);
 	return JSON.parse(content.toString()).rootfs.diff_ids;
-};
+}
 
-const getCacheId = async function (
+async function getCacheId(
 	dkroot: string,
 	driver: string,
 	layerId: string,
@@ -110,21 +121,22 @@ const getCacheId = async function (
 	// Resolves with 'rootId'
 	const content = await fs.readFile(cacheIdPath, { encoding: 'utf8' });
 	return content.toString();
-};
+}
 
-const getRandomFileName = (imageId: string): string =>
-	`tmp-${imageId.split(':')[1]}-${randomstring.generate(8)}`;
+function getRandomFileName(imageId: string): string {
+	return `tmp-${imageId.split(':')[1]}-${randomstring.generate(8)}`;
+}
 
 // Check if the docker version is a release after 1.10.0, or if its one of the fun
 // new non-semver versions, which we incidentally know all appeared after 1.10.0
 // Docker version 1.10.0 changes the way images are stored on disk and referenced
 // If the docker version supports the new "content-addressable" layer format, this function returns true
-const usesContentAddressableFormat = (version: string): boolean =>
-	!(semver.valid(version) && semver.lt(version, '1.10.0'));
+function usesContentAddressableFormat(version: string): boolean {
+	return !(semver.valid(version) && semver.lt(version, '1.10.0'));
+}
 
-const pathPrefixRemover =
-	(prefix: string): ((value: string) => string) =>
-	(value: string): string => {
+function pathPrefixRemover(prefix: string): (value: string) => string {
+	return function (value: string): string {
 		const slice = value.substr(prefix.length);
 		// return original if path doesn't start with given prefix
 		if (`${prefix}${slice}` === value) {
@@ -133,6 +145,7 @@ const pathPrefixRemover =
 			return value;
 		}
 	};
+}
 
 // This function creates an overlay2 mount using the disposer pattern,
 // calling the provided function before finally cleaning up the mount
@@ -140,14 +153,14 @@ const pathPrefixRemover =
 // await withOverlay2Mount('/abc', '/def', '/ghi', '/jkl', (mountDir) => {
 //   // ...do something with the mount
 // })
-const withOverlay2Mount = async <T>(
+async function withOverlay2Mount<T>(
 	fsRoot: string,
 	target: string,
 	lowers: string,
 	diffDir: string,
 	workDir: string,
 	fn: (mountDir: string) => T,
-): Promise<T> => {
+): Promise<T> {
 	// If no lower, just return
 	if (!lowers) {
 		return fn(diffDir);
@@ -213,7 +226,7 @@ const withOverlay2Mount = async <T>(
 			);
 		}
 	}
-};
+}
 
 // This function creates an aufs mount using the disposer pattern,
 // calling the provided function before finally cleaning up the mount
@@ -221,11 +234,11 @@ const withOverlay2Mount = async <T>(
 // await withAufsMount('/abc/def', [ '/tmp/1',/tmp/2' ], (mountDir) => {
 //   // ...do something with the mount
 // })
-const withAufsMount = async <T>(
+async function withAufsMount<T>(
 	target: string,
 	layerDiffPaths: string[], // We try to create the target directory.
 	fn: (target: string) => T,
-): Promise<T> => {
+): Promise<T> {
 	// If it exists, it's *probably* from a previous run of this same function,
 	// and the mount will fail if the directory is not empty or something's already mounted there.
 	try {
@@ -272,376 +285,395 @@ const withAufsMount = async <T>(
 			console.error('Failed to clean up after mounting aufs', err, err.stack);
 		}
 	}
-};
+}
 
-export class DockerToolbelt extends Docker {
-	// Gets an string `image` as input and returns a promise that
-	// resolves to the absolute path of the root directory for that image
-	//
-	// Note: in aufs, the path corresponds to the directory for only
-	// the specific layer's fs.
-	async imageRootDir(image: string): Promise<string> {
-		const [dockerInfo, { Version: dockerVersion }, imageInfo] =
-			await Promise.all([
-				this.info(),
-				this.version(),
-				this.getImage(image).inspect(),
-			]);
+/**
+ * Gets an string `image` as input and returns a promise that resolves to the
+ * absolute path of the root directory for that image.
+ *
+ * Note: in aufs, the path corresponds to the directory for only the specific layer's fs.
+ */
+export async function imageRootDir(
+	client: Docker,
+	image: string,
+): Promise<string> {
+	const [dockerInfo, { Version: dockerVersion }, imageInfo] = await Promise.all(
+		[client.info(), client.version(), client.getImage(image).inspect()],
+	);
 
-		const dkroot = dockerInfo.DockerRootDir;
+	const dkroot = dockerInfo.DockerRootDir;
 
-		const imageId = imageInfo.Id;
+	const imageId = imageInfo.Id;
 
-		if (!usesContentAddressableFormat(dockerVersion)) {
-			return imageId;
-		}
-
-		const diffIds = await getDiffIds(dkroot, dockerInfo.Driver, imageId);
-		const layerId = createChainId(diffIds);
-		const destId = await getCacheId(dkroot, dockerInfo.Driver, layerId);
-
-		switch (dockerInfo.Driver) {
-			case 'btrfs':
-				return path.join(dkroot, 'btrfs/subvolumes', destId);
-			case 'overlay':
-				// TODO: fix any typing
-				return (imageInfo.GraphDriver.Data as any).RootDir;
-			case 'overlay2':
-				// TODO: fix any typing
-				return (imageInfo.GraphDriver.Data as any).UpperDir;
-			case 'vfs':
-				return path.join(dkroot, 'vfs/dir', destId);
-			case 'aufs':
-				return path.join(dkroot, 'aufs/diff', destId);
-			default:
-				throw new Error(`Unsupported driver: ${dockerInfo.Driver}/`);
-		}
-	}
-
-	// Same as imageRootDir, but provides the full mounted rootfs for AUFS and overlay2,
-	// and has a disposer to unmount.
-	async withImageRootDirMounted<T>(
-		image: string,
-		fn: (target: string) => T,
-	): Promise<T> {
-		const [dockerInfo, imageInfo] = await Promise.all([
-			this.info(),
-			this.getImage(image).inspect(),
-		]);
-
-		const driver = dockerInfo.Driver;
-		const dkroot = dockerInfo.DockerRootDir;
-		const imageId = imageInfo.Id;
-		// We add a random string to the path to avoid conflicts between several calls to this function
-		if (driver === 'aufs') {
-			const layerDiffPaths = await this.diffPaths(image);
-			const mountDir = path.join(
-				dkroot,
-				'aufs/mnt',
-				getRandomFileName(imageId),
-			);
-			return withAufsMount<T>(mountDir, layerDiffPaths, fn);
-		} else if (driver === 'overlay2') {
-			const rootDir = path.join(dkroot, 'overlay2');
-			const mountDir = path.join(rootDir, getRandomFileName(imageId));
-			// TODO: fix this any typing
-			const { LowerDir, UpperDir, WorkDir } = imageInfo.GraphDriver.Data as any;
-			return withOverlay2Mount<T>(
-				rootDir,
-				mountDir,
-				LowerDir,
-				UpperDir,
-				WorkDir,
-				fn,
-			);
-		} else {
-			const rootDir = await this.imageRootDir(image);
-			return fn(rootDir);
-		}
-	}
-
-	// Only for aufs and overlay2: get the diff paths for each layer in the image.
-	// Ordered from latest to parent.
-	async diffPaths(image: string): Promise<string[]> {
-		const [dockerInfo, { Version: dockerVersion }, imageInfo] =
-			await Promise.all([
-				this.info(),
-				this.version(),
-				this.getImage(image).inspect(),
-			]);
-
-		const driver = dockerInfo.Driver;
-		if (!(driver === 'aufs' || driver === 'overlay2')) {
-			throw new Error('diffPaths can only be used on aufs and overlay2');
-		}
-		const dkroot = dockerInfo.DockerRootDir;
-		const imageId = imageInfo.Id;
-		const ids = await getDiffIds(dkroot, driver, imageId).then(function (
-			diffIds,
-		) {
-			if (!usesContentAddressableFormat(dockerVersion)) {
-				return diffIds;
-			}
-			return Promise.all(
-				getAllChainIds(diffIds).map(async (layerId) =>
-					getCacheId(dkroot, driver, layerId),
-				),
-			);
-		});
-		return ids.reverse().map<string>(function (layerId: string) {
-			return driver === 'aufs'
-				? path.join(dkroot, 'aufs/diff', layerId)
-				: path.join(dkroot, 'overlay2', layerId, 'diff');
-		});
-	}
-
-	// Given an image configuration it constructs a valid tar archive in the same
-	// way a `docker save` would have done that contains an empty filesystem image
-	// with the given configuration.
-	//
-	// We have to go through the `docker load` mechanism in order for docker to
-	// compute the correct digests and properly load it in the content store
-	//
-	// It returns a promise that resolves to the new image id
-	async createEmptyImage(imageConfig: any): Promise<string> {
-		const manifest = [
-			{
-				Config: 'config.json',
-				RepoTags: null,
-				Layers: ['0000/layer.tar'],
-			},
-		];
-
-		// Since docker versions after 1.10 use a content addressable store we have
-		// to make sure we always load a uniqe image so that we end up with
-		// different image IDs on which we can later apply a delta stream
-		const layer = tar.pack();
-		layer.entry({ name: 'seed' }, String(Date.now() + Math.random()));
-		layer.finalize();
-
-		const buf = await promiseFromCallback<string>((callback) =>
-			layer.pipe(es.wait(callback)),
-		);
-		const now = new Date().toISOString();
-
-		const config = {
-			config: imageConfig,
-			created: now,
-			rootfs: {
-				type: 'layers',
-				diff_ids: [getDigest(buf)],
-			},
-		};
-
-		const imageId = sha256sum(JSON.stringify(config));
-
-		const layerConfig = {
-			id: imageId,
-			created: now,
-			config: imageConfig,
-		};
-
-		const image = tar.pack();
-		image.entry({ name: 'manifest.json' }, JSON.stringify(manifest));
-		image.entry({ name: 'config.json' }, JSON.stringify(config));
-		image.entry({ name: '0000/VERSION' }, '1.0');
-		image.entry({ name: '0000/json' }, JSON.stringify(layerConfig));
-		image.entry({ name: '0000/layer.tar' }, buf);
-
-		image.finalize();
-
-		const stream = await this.loadImage(image);
-		await promiseFromCallback((callback) => stream.pipe(es.wait(callback)));
+	if (!usesContentAddressableFormat(dockerVersion)) {
 		return imageId;
 	}
 
-	/**
-	 * Given a source and a destination image, invokes `/images/delta` and returns a
-	 * promise to a readable stream for following progress. Can also be called with a
-	 * callback as the second argument instead, similar to how Dockerode methods
-	 * support both a callback and async interface.
-	 *
-	 * Callers can extract the delta image ID by parsing the stream like so:
-	 *
-	 * ```
-	 * const stream = await docker.createDelta({ src, dest });
-	 * const deltaId = await new Promise<string>((resolve, reject) => {
-	 *   let imageId: string | undefined = null;
-	 *   function onFinish(err) {
-	 *     if (err != null) {
-	 *       return reject(err);
-	 *     }
-	 *     if (imageId == null) {
-	 *       return reject(new Error('failed to parse delta image ID!'));
-	 *     }
-	 *     resolve(imageId);
-	 *   }
-	 *   docker.modem.followProgress(stream, onFinish, (e: any) => {
-	 *     const match = /^Created delta: (sha256:\w+)$/.exec(e.status);
-	 *     if (match && imageId == null) {
-	 *       imageId = match[1];
-	 *     }
-	 *   });
-	 * });
-	 * ```
-	 *
-	 * Deltas are currently only available with balenaEngine, but this method makes
-	 * no effort to determine whether that's the case.
-	 */
-	async createDelta(opts: CreateDeltaOptions): Promise<NodeJS.ReadableStream>;
-	createDelta(
-		opts: CreateDeltaOptions,
-		callback: Callback<NodeJS.ReadableStream>,
-	): void;
-	createDelta(
-		opts: CreateDeltaOptions,
-		callback?: Callback<NodeJS.ReadableStream>,
-	): void | Promise<NodeJS.ReadableStream> {
-		const optsf = {
-			path: '/images/delta?',
-			method: 'POST',
-			options: opts,
-			isStream: true,
-			statusCodes: {
-				200: true,
-				404: 'no such image',
-				500: 'server error',
-			},
-		};
-		if (callback == null) {
-			const modem = this.modem;
-			return new modem.Promise(function (resolve, reject) {
-				modem.dial(optsf, function (err, data) {
-					if (err) {
-						return reject(err);
-					}
-					resolve(data as NodeJS.ReadableStream);
-				});
-			});
-		} else {
-			this.modem.dial(optsf, function (err, data) {
-				callback(err, data as NodeJS.ReadableStream);
-			});
+	const diffIds = await getDiffIds(dkroot, dockerInfo.Driver, imageId);
+	const layerId = createChainId(diffIds);
+	const destId = await getCacheId(dkroot, dockerInfo.Driver, layerId);
+
+	switch (dockerInfo.Driver) {
+		case 'btrfs':
+			return path.join(dkroot, 'btrfs/subvolumes', destId);
+		case 'overlay':
+			// TODO: fix any typing
+			return (imageInfo.GraphDriver.Data as any).RootDir;
+		case 'overlay2':
+			// TODO: fix any typing
+			return (imageInfo.GraphDriver.Data as any).UpperDir;
+		case 'vfs':
+			return path.join(dkroot, 'vfs/dir', destId);
+		case 'aufs':
+			return path.join(dkroot, 'aufs/diff', destId);
+		default:
+			throw new Error(`Unsupported driver: ${dockerInfo.Driver}/`);
+	}
+}
+
+/**
+ * Same as imageRootDir, but provides the full mounted rootfs for AUFS and
+ * overlay2, and has a disposer to unmount.
+ */
+export async function withImageRootDirMounted<T>(
+	client: Docker,
+	image: string,
+	fn: (target: string) => T,
+): Promise<T> {
+	const [dockerInfo, imageInfo] = await Promise.all([
+		client.info(),
+		client.getImage(image).inspect(),
+	]);
+
+	const driver = dockerInfo.Driver;
+	const dkroot = dockerInfo.DockerRootDir;
+	const imageId = imageInfo.Id;
+	// We add a random string to the path to avoid conflicts between several calls to this function
+	if (driver === 'aufs') {
+		const layerDiffPaths = await diffPaths(client, image);
+		const mountDir = path.join(dkroot, 'aufs/mnt', getRandomFileName(imageId));
+		return withAufsMount<T>(mountDir, layerDiffPaths, fn);
+	} else if (driver === 'overlay2') {
+		const rootDir = path.join(dkroot, 'overlay2');
+		const mountDir = path.join(rootDir, getRandomFileName(imageId));
+		// TODO: fix this any typing
+		const { LowerDir, UpperDir, WorkDir } = imageInfo.GraphDriver.Data as any;
+		return withOverlay2Mount<T>(
+			rootDir,
+			mountDir,
+			LowerDir,
+			UpperDir,
+			WorkDir,
+			fn,
+		);
+	} else {
+		const rootDir = await imageRootDir(client, image);
+		return fn(rootDir);
+	}
+}
+
+/**
+ * Get the diff paths for each layer in the image, ordered from latest to parent.
+ *
+ * Only for aufs and overlay2.
+ */
+export async function diffPaths(
+	client: Docker,
+	image: string,
+): Promise<string[]> {
+	const [dockerInfo, { Version: dockerVersion }, imageInfo] = await Promise.all(
+		[client.info(), client.version(), client.getImage(image).inspect()],
+	);
+
+	const driver = dockerInfo.Driver;
+	if (!(driver === 'aufs' || driver === 'overlay2')) {
+		throw new Error('diffPaths can only be used on aufs and overlay2');
+	}
+	const dkroot = dockerInfo.DockerRootDir;
+	const imageId = imageInfo.Id;
+	const ids = await getDiffIds(dkroot, driver, imageId).then(function (
+		diffIds,
+	) {
+		if (!usesContentAddressableFormat(dockerVersion)) {
+			return diffIds;
 		}
+		return Promise.all(
+			getAllChainIds(diffIds).map(async (layerId) =>
+				getCacheId(dkroot, driver, layerId),
+			),
+		);
+	});
+	return ids.reverse().map<string>(function (layerId: string) {
+		return driver === 'aufs'
+			? path.join(dkroot, 'aufs/diff', layerId)
+			: path.join(dkroot, 'overlay2', layerId, 'diff');
+	});
+}
+
+/**
+ * Given an image configuration it constructs a valid tar archive in the same
+ * way a `docker save` would have done that contains an empty filesystem image
+ * with the given configuration.
+ *
+ * We have to go through the `docker load` mechanism in order for docker to
+ * compute the correct digests and properly load it in the content store.
+ *
+ * It returns a promise that resolves to the new image id.
+ */
+export async function createEmptyImage(
+	client: Docker,
+	imageConfig: any,
+): Promise<string> {
+	const manifest = [
+		{
+			Config: 'config.json',
+			RepoTags: null,
+			Layers: ['0000/layer.tar'],
+		},
+	];
+
+	// Since docker versions after 1.10 use a content addressable store we have
+	// to make sure we always load a uniqe image so that we end up with
+	// different image IDs on which we can later apply a delta stream
+	const layer = tar.pack();
+	layer.entry({ name: 'seed' }, String(Date.now() + Math.random()));
+	layer.finalize();
+
+	const buf = await waitStream<string>(layer);
+	const now = new Date().toISOString();
+
+	const config = {
+		config: imageConfig,
+		created: now,
+		rootfs: {
+			type: 'layers',
+			diff_ids: [getDigest(buf)],
+		},
+	};
+
+	const imageId = sha256sum(JSON.stringify(config));
+
+	const layerConfig = {
+		id: imageId,
+		created: now,
+		config: imageConfig,
+	};
+
+	const image = tar.pack();
+	image.entry({ name: 'manifest.json' }, JSON.stringify(manifest));
+	image.entry({ name: 'config.json' }, JSON.stringify(config));
+	image.entry({ name: '0000/VERSION' }, '1.0');
+	image.entry({ name: '0000/json' }, JSON.stringify(layerConfig));
+	image.entry({ name: '0000/layer.tar' }, buf);
+
+	image.finalize();
+
+	const stream = await client.loadImage(image);
+	await waitStream(stream);
+	return imageId;
+}
+
+/**
+ * Given a source and a destination image, invokes `/images/delta` and returns a
+ * promise to a readable stream for following progress. Can also be called with a
+ * callback as the second argument instead, similar to how Dockerode methods
+ * support both a callback and async interface.
+ *
+ * Callers can extract the delta image ID by parsing the stream like so:
+ *
+ * ```
+ * const stream = await docker.createDelta({ src, dest });
+ * const deltaId = await new Promise<string>((resolve, reject) => {
+ *   let imageId: string | undefined = null;
+ *   function onFinish(err) {
+ *     if (err != null) {
+ *       return reject(err);
+ *     }
+ *     if (imageId == null) {
+ *       return reject(new Error('failed to parse delta image ID!'));
+ *     }
+ *     resolve(imageId);
+ *   }
+ *   docker.modem.followProgress(stream, onFinish, (e: any) => {
+ *     const match = /^Created delta: (sha256:\w+)$/.exec(e.status);
+ *     if (match && imageId == null) {
+ *       imageId = match[1];
+ *     }
+ *   });
+ * });
+ * ```
+ *
+ * Deltas are currently only available with balenaEngine, but this method makes
+ * no effort to determine whether that's the case.
+ */
+export async function createDelta(
+	client: Docker,
+	opts: CreateDeltaOptions,
+): Promise<NodeJS.ReadableStream>;
+export function createDelta(
+	client: Docker,
+	opts: CreateDeltaOptions,
+	callback: Callback<NodeJS.ReadableStream>,
+): void;
+export function createDelta(
+	client: Docker,
+	opts: CreateDeltaOptions,
+	callback?: Callback<NodeJS.ReadableStream>,
+): void | Promise<NodeJS.ReadableStream> {
+	const optsf = {
+		path: '/images/delta?',
+		method: 'POST',
+		options: opts,
+		isStream: true,
+		statusCodes: {
+			200: true,
+			404: 'no such image',
+			500: 'server error',
+		},
+	};
+	const { modem } = client;
+	if (callback == null) {
+		return new modem.Promise(function (resolve, reject) {
+			modem.dial(optsf, function (err, data) {
+				if (err) {
+					return reject(err);
+				}
+				resolve(data as NodeJS.ReadableStream);
+			});
+		});
+	} else {
+		modem.dial(optsf, function (err, data) {
+			callback(err, data as NodeJS.ReadableStream);
+		});
+	}
+}
+
+/**
+ * Separate string containing registry and image name into its parts.
+ *
+ * ```
+ * > getRegistryAndName('registry.resinstaging.io/resin/rpi')
+ * => { registry: "registry.resinstaging.io", imageName: "resin/rpi" }
+ * ```
+ */
+export function getRegistryAndName(image: string): ImageNameParts {
+	// Matches (registry)/(repo)(optional :tag or @digest)
+	// regex adapted from Docker's source code:
+	// https://github.com/docker/distribution/blob/release/2.7/reference/normalize.go#L62
+	// https://github.com/docker/distribution/blob/release/2.7/reference/regexp.go#L44
+	const match = image.match(
+		/^(?:(localhost|.*?[.:].*?)\/)?(.+?)(?::(.*?))?(?:@(.*?))?$/,
+	);
+	if (match == null) {
+		throw new Error(`Could not parse the image: ${image}`);
+	}
+	const registry = match[match.length - 4];
+	const imageName = match[match.length - 3];
+	let tagName = match[match.length - 2];
+	const digest = match[match.length - 1];
+	if (digest == null && tagName == null) {
+		tagName = 'latest';
+	}
+	const digestMatch =
+		digest != null
+			? digest.match(
+					/^[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9a-f-A-F]{32,}$/,
+			  )
+			: undefined;
+	if (!imageName || (digest && !digestMatch)) {
+		throw new Error(
+			'Invalid image name, expected [domain.tld/]repo/image[:tag][@digest] format',
+		);
+	}
+	return { registry, imageName, tagName, digest };
+}
+
+/**
+ * Given an object representing a docker image, in the same format as given by
+ * getRegistryAndName, compile it back into a docker image string, which can be
+ * used in Docker command etc.
+ *
+ * ```
+ * > compileRegistryAndName({ registry: "registry.resinstaging.io", imageName: "resin/rpi", tagName: "1234"})
+ * => 'registry.resinstaging.io/resin/rpi:1234'
+ * ```
+ */
+export function compileRegistryAndName({
+	registry = '',
+	imageName,
+	tagName = '',
+	digest,
+}: ImageNameParts): string {
+	if (registry !== '') {
+		registry += '/';
 	}
 
-	// Separate string containing registry and image name into its parts.
-	// Example: registry.resinstaging.io/resin/rpi
-	//          { registry: "registry.resinstaging.io", imageName: "resin/rpi" }
-	getRegistryAndName(image: string): ImageNameParts {
-		// Matches (registry)/(repo)(optional :tag or @digest)
-		// regex adapted from Docker's source code:
-		// https://github.com/docker/distribution/blob/release/2.7/reference/normalize.go#L62
-		// https://github.com/docker/distribution/blob/release/2.7/reference/regexp.go#L44
-		const match = image.match(
-			/^(?:(localhost|.*?[.:].*?)\/)?(.+?)(?::(.*?))?(?:@(.*?))?$/,
-		);
-		if (match == null) {
-			throw new Error(`Could not parse the image: ${image}`);
-		}
-		const registry = match[match.length - 4];
-		const imageName = match[match.length - 3];
-		let tagName = match[match.length - 2];
-		const digest = match[match.length - 1];
-		if (digest == null && tagName == null) {
+	if (digest == null) {
+		if (tagName === '') {
 			tagName = 'latest';
 		}
-		const digestMatch =
-			digest != null
-				? digest.match(
-						/^[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9a-f-A-F]{32,}$/,
-				  )
-				: undefined;
-		if (!imageName || (digest && !digestMatch)) {
-			throw new Error(
-				'Invalid image name, expected [domain.tld/]repo/image[:tag][@digest] format',
-			);
+		return `${registry}${imageName}:${tagName}`;
+	} else {
+		// Intentionally discard the tag when a digest exists
+		return `${registry}${imageName}@${digest}`;
+	}
+}
+
+/**
+ * Normalise an image name to always have a tag, with :latest being the default
+ */
+export function normaliseImageName(image: string): string {
+	const result = getRegistryAndName(image);
+	return compileRegistryAndName(result);
+}
+
+export async function isBalenaEngine(client: Docker): Promise<boolean> {
+	const versionInfo = await client.version();
+	const engine = (versionInfo as any)['Engine'];
+	if (engine == null) {
+		return false;
+	}
+	return ['balena', 'balaena', 'balena-engine'].includes(engine.toLowerCase());
+}
+
+/**
+ * DockerModem.followProgress *buffers all events internally* and
+ * hands them all to the onFinish callback. This function is a copy
+ * of that *without* the buffering.
+ */
+export function followProgressUnbuffered(
+	stream: NodeJS.ReadableStream,
+	onFinished: (err: Error | null) => void,
+	onProgress?: (event: any) => void,
+) {
+	const parser = JSONStream.parse(undefined);
+
+	parser.on('data', onStreamEvent);
+	parser.on('error', onStreamError);
+	parser.on('end', onStreamEnd);
+
+	stream.pipe(parser);
+
+	function onStreamEvent(evt: any) {
+		if (!(evt instanceof Object)) {
+			evt = {};
 		}
-		return { registry, imageName, tagName, digest };
+		if (evt.error) {
+			return onStreamError(evt.error);
+		}
+		if (onProgress) {
+			onProgress(evt);
+		}
 	}
 
-	// Given an object representing a docker image, in the same format as given
-	// by getRegistryAndName, compile it back into a docker image string, which
-	// can be used in Docker command etc
-	// Example: { registry: "registry.resinstaging.io", imageName: "resin/rpi", tagName: "1234"}
-	// 		=> registry.resinstaging.io/resin/rpi:1234
-	compileRegistryAndName({
-		registry = '',
-		imageName,
-		tagName = '',
-		digest,
-	}: ImageNameParts): string {
-		if (registry !== '') {
-			registry += '/';
-		}
-
-		if (digest == null) {
-			if (tagName === '') {
-				tagName = 'latest';
-			}
-			return `${registry}${imageName}:${tagName}`;
-		} else {
-			// Intentionally discard the tag when a digest exists
-			return `${registry}${imageName}@${digest}`;
-		}
+	function onStreamError(err: Error) {
+		parser.removeListener('data', onStreamEvent);
+		parser.removeListener('error', onStreamError);
+		parser.removeListener('end', onStreamEnd);
+		onFinished(err);
 	}
 
-	// Normalise an image name to always have a tag, with :latest being the default
-	normaliseImageName(image: string): string {
-		const result = this.getRegistryAndName(image);
-		return this.compileRegistryAndName(result);
-	}
-
-	async isBalenaEngine(): Promise<boolean> {
-		const versionInfo = await this.version();
-		const engine = (versionInfo as any)['Engine'];
-		if (engine == null) {
-			return false;
-		}
-		return ['balena', 'balaena', 'balena-engine'].includes(
-			engine.toLowerCase(),
-		);
-	}
-
-	/**
-	 * DockerModem.followProgress *buffers all events internally* and
-	 * hands them all to the onFinish callback. This function is a copy
-	 * of that *without* the buffering.
-	 */
-	followProgressUnbuffered(
-		stream: NodeJS.ReadableStream,
-		onFinished: (err: Error | null) => void,
-		onProgress?: (event: any) => void,
-	) {
-		const parser = JSONStream.parse(undefined);
-
-		parser.on('data', onStreamEvent);
-		parser.on('error', onStreamError);
-		parser.on('end', onStreamEnd);
-
-		stream.pipe(parser);
-
-		function onStreamEvent(evt: any) {
-			if (!(evt instanceof Object)) {
-				evt = {};
-			}
-			if (evt.error) {
-				return onStreamError(evt.error);
-			}
-			if (onProgress) {
-				onProgress(evt);
-			}
-		}
-
-		function onStreamError(err: Error) {
-			parser.removeListener('data', onStreamEvent);
-			parser.removeListener('error', onStreamError);
-			parser.removeListener('end', onStreamEnd);
-			onFinished(err);
-		}
-
-		function onStreamEnd() {
-			onFinished(null);
-		}
+	function onStreamEnd() {
+		onFinished(null);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rimraf build",
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "git+https://github.com/balena-io-modules/docker-toolbelt.git"
   },
-  "author": "Petros Angelatos",
+  "author": "Balena Ltd.",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/balena-io-modules/docker-toolbelt/issues"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "balena-semver": "^2.2.0",
     "dockerode": "^3.3.5",
     "event-stream": "3.3.5",
+    "JSONStream": "^1.3.5",
     "randomstring": "^1.1.5",
     "tar-stream": "^2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
   },
   "homepage": "https://github.com/balena-io-modules/docker-toolbelt#readme",
   "dependencies": {
-    "@types/dockerode": "^3.3.19",
-    "@types/event-stream": "^3.3.34",
-    "@types/randomstring": "^1.1.8",
-    "@types/tar-stream": "^2.1.0",
     "balena-semver": "^2.2.0",
-    "dockerode": "^3.3.5",
     "event-stream": "3.3.5",
     "JSONStream": "^1.3.5",
     "randomstring": "^1.1.5",
@@ -42,17 +37,22 @@
   "devDependencies": {
     "@balena/lint": "^5.1.0",
     "@types/chai": "^4.2.22",
+    "@types/dockerode": "^3.3.19",
+    "@types/event-stream": "^3.3.34",
     "@types/mocha": "^9.0.0",
-    "@types/sinon": "^10.0.6",
+    "@types/randomstring": "^1.1.8",
+    "@types/tar-stream": "^2.1.0",
     "chai": "^4.3.4",
     "mocha": "^8.4.0",
     "rimraf": "^3.0.2",
-    "sinon": "^12.0.1",
     "ts-node": "^10.4.0",
     "typedoc": "^0.22.9",
     "typescript": "^4.4.4"
   },
   "versionist": {
     "publishedAt": "2023-06-30T08:51:05.413Z"
+  },
+  "peerDependencies": {
+    "dockerode": "^3.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "chai": "^4.3.4",
     "mocha": "^8.4.0",
     "rimraf": "^3.0.2",
-    "ts-node": "^10.4.0",
-    "typedoc": "^0.22.9",
-    "typescript": "^4.4.4"
+    "ts-node": "^10.9.1",
+    "typedoc": "^0.24.8",
+    "typescript": "^5.1.6"
   },
   "versionist": {
     "publishedAt": "2023-06-30T08:51:05.413Z"

--- a/tests/all.spec.ts
+++ b/tests/all.spec.ts
@@ -1,55 +1,9 @@
-import Dockerode from 'dockerode';
-import { DockerToolbelt } from '../lib';
+import * as dt from '../lib';
 import { expect } from 'chai';
-import { stub } from 'sinon';
 
 describe('DockerToolbelt', function () {
-	const d = new DockerToolbelt({ socketPath: '/foo/docker.sock' });
-
-	it('instantiates a docker object with the passed options', function () {
-		expect(d).to.have.property('modem');
-		return expect((d.modem as any).socketPath).to.equal('/foo/docker.sock');
-	});
-
-	it('provides promisified docker functions', function () {
-		stub(d.modem, 'dial').callsArgWith(1, null, [{ id: '1' }, { id: '2' }]);
-		return d.listImages().then((images) => {
-			(d.modem.dial as any).restore();
-			return expect(images).to.deep.equal([{ id: '1' }, { id: '2' }]);
-		});
-	});
-
-	it('provides promisified functions for docker images', function () {
-		const img = d.getImage('nonExistentImageName1234');
-		// This call is expected to throw either because there's no docker or the image doesn't exist
-		// But all we care about is that it throws
-		const promise = img.inspect();
-		expect(promise).to.be.an.instanceOf(Promise);
-		// tslint:disable-next-line: no-empty
-		promise.catch(function () {});
-		return expect(promise).to.throw;
-	});
-
-	it('provides promisified functions for docker containers', function () {
-		const c = d.getContainer('nonExistentContainerName1234');
-		// This call is expected to throw either because there's no docker or the image doesn't exist
-		// But all we care about is that it throws
-		const promise = c.inspect();
-		expect(promise).to.be.an.instanceOf(Promise);
-		// tslint:disable-next-line: no-empty
-		promise.catch(function () {});
-		return expect(promise).to.throw;
-	});
-
-	it('does not mutate the dockerode library', function () {
-		const d2 = new Dockerode();
-		expect((d2 as any).listImagesAsync).to.be.undefined;
-		expect((d2.getImage('foo') as any).inspectAsync).to.be.undefined;
-		return expect((d2 as any).diffPaths).to.be.undefined;
-	});
-
 	it('splits an image name into its components with getRegistryAndName', function () {
-		const components = d.getRegistryAndName(
+		const components = dt.getRegistryAndName(
 			'someregistry.com/some/repo:sometag',
 		);
 		expect(components).to.deep.equal({
@@ -61,7 +15,7 @@ describe('DockerToolbelt', function () {
 	});
 
 	it('splits an image name into its components defaulting tag to latest with getRegistryAndName', function () {
-		const components = d.getRegistryAndName('someregistry.com/some/repo');
+		const components = dt.getRegistryAndName('someregistry.com/some/repo');
 		expect(components).to.deep.equal({
 			registry: 'someregistry.com',
 			imageName: 'some/repo',
@@ -71,7 +25,7 @@ describe('DockerToolbelt', function () {
 	});
 
 	it('matches an image name with digest with getRegistryAndName', function () {
-		const components = d.getRegistryAndName(
+		const components = dt.getRegistryAndName(
 			'someregistry.com/some/repo@sha256:0123456789abcdef0123456789abcdef',
 		);
 		expect(components).to.deep.equal({
@@ -84,7 +38,7 @@ describe('DockerToolbelt', function () {
 
 	it('throws when running getRegistryAndName if the image name has an invalid digest', function () {
 		expect(() =>
-			d.getRegistryAndName(
+			dt.getRegistryAndName(
 				'someregistry.com/some/repo@sha256:0123456789abcdef0123456789abcdeg',
 			),
 		).to.throw;
@@ -133,7 +87,7 @@ describe('DockerToolbelt', function () {
 			],
 		];
 		testVector.forEach(([fullName, [registry, imageName, tagName, digest]]) => {
-			const components = d.getRegistryAndName(fullName as string);
+			const components = dt.getRegistryAndName(fullName as string);
 			expect(components).to.deep.equal({
 				registry,
 				imageName,
@@ -186,7 +140,7 @@ describe('DockerToolbelt', function () {
 			],
 		];
 		testVector.forEach(([expected, [registry, imageName, tagName, digest]]) => {
-			const fullName = d.compileRegistryAndName({
+			const fullName = dt.compileRegistryAndName({
 				registry,
 				imageName,
 				tagName,

--- a/tests/docker-toolbelt.spec.ts
+++ b/tests/docker-toolbelt.spec.ts
@@ -133,9 +133,7 @@ describe('DockerToolbelt', function () {
 			],
 		];
 		testVector.forEach(([fullName, [registry, imageName, tagName, digest]]) => {
-			const components = DockerToolbelt.prototype.getRegistryAndName(
-				fullName as string,
-			);
+			const components = d.getRegistryAndName(fullName as string);
 			expect(components).to.deep.equal({
 				registry,
 				imageName,
@@ -145,7 +143,7 @@ describe('DockerToolbelt', function () {
 		});
 	});
 
-	return it('successfully compiles a list of sample docker image names', function () {
+	it('successfully compiles a list of sample docker image names', function () {
 		const u = undefined;
 		const testVector = [
 			['busybox:latest', [u, 'busybox', u, u]],
@@ -187,19 +185,14 @@ describe('DockerToolbelt', function () {
 				['eu.gcr.io', 'aa-bb-33/foo/bar', '', u],
 			],
 		];
-		return Promise.all(
-			testVector.map(
-				([expectedFullName, [registry, imageName, tagName, digest]]) => {
-					return DockerToolbelt.prototype
-						.compileRegistryAndName({
-							registry,
-							imageName,
-							tagName,
-							digest,
-						} as any)
-						.then((fullName) => expect(fullName).to.equal(expectedFullName));
-				},
-			),
-		);
+		testVector.forEach(([expected, [registry, imageName, tagName, digest]]) => {
+			const fullName = d.compileRegistryAndName({
+				registry,
+				imageName,
+				tagName,
+				digest,
+			} as any);
+			expect(fullName).to.equal(expected);
+		});
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"removeComments": true,
 		"sourceMap": true,
 		"strict": true,
-		"target": "es2015",
+		"target": "es2021",
 		"declaration": true,
 		"skipLibCheck": true,
 		"esModuleInterop": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,9 @@
 	"include": [
 		"lib/**/*.ts",
 		"tests/**/*.ts",
-	]
+		"typings/**/*.d.ts",
+	],
+	"ts-node": {
+		"files": true
+	}
 }

--- a/typings/JSONStream.d.ts
+++ b/typings/JSONStream.d.ts
@@ -1,0 +1,4 @@
+declare module 'JSONStream' {
+	export function parse(pattern?: any): NodeJS.ReadWriteStream;
+	export function stringify(flag?: false): NodeJS.ReadWriteStream;
+}


### PR DESCRIPTION
- Drop support for Node versions before v18 
- Remove redundant async-ness from a few methods 
- Rename createDeltaAsync and rewrite it to follow Dockerode’s method style
- Add method to identify balenaEngine 
- Add method to follow stream progress without buffering to memory 
- Make Dockerode a peer dep and export plain functions
- Update to Typescript v5

Change-type: major